### PR TITLE
Tailer now supports empty messages

### DIFF
--- a/tailer/tailer.go
+++ b/tailer/tailer.go
@@ -185,7 +185,7 @@ func (t *Tailer) IterateReverse(maxOffset int64, visit TailerVisiter) error {
 	defer t.m.RUnlock()
 
 	if t.numItems == 0 {
-		return fmt.Errorf("kafka topic does not have msg")
+		nil
 	}
 
 	numIterations := t.numItems

--- a/tailer/tailer.go
+++ b/tailer/tailer.go
@@ -185,7 +185,7 @@ func (t *Tailer) IterateReverse(maxOffset int64, visit TailerVisiter) error {
 	defer t.m.RUnlock()
 
 	if t.numItems == 0 {
-		nil
+		return nil
 	}
 
 	numIterations := t.numItems


### PR DESCRIPTION
With this PR, the tailer will tolerate topics with no message. Currently, it returns an error if there's no message.